### PR TITLE
fix(jolt): expose AsyncSignal fetch and state helpers

### DIFF
--- a/docs/src/jolt/advanced/async-signal.md
+++ b/docs/src/jolt/advanced/async-signal.md
@@ -95,31 +95,6 @@ final stream = Stream.periodic(Duration(seconds: 1), (i) => i);
 final dataSignal = AsyncSignal.fromStream(stream);
 ```
 
-### Using Extension Methods
-
-Jolt provides extension methods for more convenient async signal creation:
-
-From Future:
-
-```dart
-Future<String> fetchData() async {
-  await Future.delayed(Duration(seconds: 1));
-  return 'Data';
-}
-
-final signal = fetchData().toAsyncSignal();
-```
-
-From Stream:
-
-```dart
-Stream<int> getDataStream() {
-  return Stream.periodic(Duration(seconds: 1), (i) => i);
-}
-
-final signal = getDataStream().toStreamSignal();
-```
-
 ### Using AsyncSource
 
 You can create using a custom `AsyncSource`:

--- a/docs/src/zh/jolt/advanced/async-signal.md
+++ b/docs/src/zh/jolt/advanced/async-signal.md
@@ -95,31 +95,6 @@ final stream = Stream.periodic(Duration(seconds: 1), (i) => i);
 final dataSignal = AsyncSignal.fromStream(stream);
 ```
 
-### 使用扩展方法创建
-
-Jolt 提供了扩展方法，可以更方便地创建异步信号：
-
-从 Future 创建：
-
-```dart
-Future<String> fetchData() async {
-  await Future.delayed(Duration(seconds: 1));
-  return 'Data';
-}
-
-final signal = fetchData().toAsyncSignal();
-```
-
-从 Stream 创建：
-
-```dart
-Stream<int> getDataStream() {
-  return Stream.periodic(Duration(seconds: 1), (i) => i);
-}
-
-final signal = getDataStream().toStreamSignal();
-```
-
 ### 使用 AsyncSource 创建
 
 可以使用自定义的 `AsyncSource` 创建：

--- a/packages/jolt/lib/src/jolt/async.dart
+++ b/packages/jolt/lib/src/jolt/async.dart
@@ -2,6 +2,7 @@ import "dart:async";
 
 import "package:jolt/core.dart";
 import "package:jolt/src/jolt/signal.dart";
+import "package:meta/meta.dart";
 import "package:shared_interfaces/shared_interfaces.dart";
 
 /// Represents the state of an asynchronous operation.
@@ -320,28 +321,74 @@ class AsyncSignalImpl<T> extends SignalImpl<AsyncState<T>>
   @override
   T? get data => value.data;
 
-  Disposer? _sourceDisposer;
+  @override
+  bool get isLoading => value.isLoading;
 
+  @override
+  bool get isSuccess => value.isSuccess;
+
+  @override
+  bool get isError => value.isError;
+
+  @override
+  Object? get error => value.error;
+
+  @override
+  StackTrace? get stackTrace => value.stackTrace;
+
+  @pragma("vm:prefer-inline")
+  @pragma("wasm:prefer-inline")
+  @pragma("dart2js:prefer-inline")
+  @override
+  R? map<R>({
+    R Function()? loading,
+    R Function(T)? success,
+    R Function(Object?, StackTrace?)? error,
+  }) =>
+      value.map(
+        loading: loading,
+        success: success,
+        error: error,
+      );
+
+  Disposer? _sourceDisposer;
+  Object? _objId;
+
+  @override
   Future<void> fetch(AsyncSource<T> source) async {
+    if (isDisposed) return;
+    final objId = Object();
+    _objId = objId;
+
     _sourceDisposer?.call();
-    _sourceDisposer = null;
+    _sourceDisposer = source.dispose;
 
     void emit(AsyncState<T> state) {
-      if (!isDisposed) value = state;
-    }
-
-    final future = source.subscribe(emit);
-    _sourceDisposer = source.dispose;
-    final currentDisposer = source.dispose;
-
-    try {
-      await future;
-    } finally {
-      if (_sourceDisposer == currentDisposer) {
-        _sourceDisposer = null;
-        currentDisposer();
+      if (_objId == objId) {
+        value = state;
       }
     }
+
+    try {
+      await source.subscribe(emit);
+    } finally {
+      if (_objId == objId) {
+        _objId = null;
+        final disposer = _sourceDisposer;
+        _sourceDisposer = null;
+        disposer?.call();
+      }
+    }
+  }
+
+  @override
+  @mustCallSuper
+  @protected
+  void onDispose() {
+    super.onDispose();
+    _objId = null;
+    _sourceDisposer?.call();
+    _sourceDisposer = null;
   }
 }
 
@@ -426,4 +473,37 @@ abstract interface class AsyncSignal<T> implements Signal<AsyncState<T>> {
   /// final data = signal.data; // null if loading or error
   /// ```
   T? get data;
+
+  /// Whether the current state represents a loading operation.
+  bool get isLoading;
+
+  /// Whether the current state represents a successful operation with data.
+  bool get isSuccess;
+
+  /// Whether the current state represents an error.
+  bool get isError;
+
+  /// The error from the current async state, if any.
+  Object? get error;
+
+  /// The stack trace from the current async error state, if any.
+  StackTrace? get stackTrace;
+
+  /// Maps the current async state to a value based on its state variant.
+  R? map<R>({
+    R Function()? loading,
+    R Function(T)? success,
+    R Function(Object?, StackTrace?)? error,
+  });
+
+  /// Replaces the current async source and subscribes to the new one.
+  ///
+  /// This can be used to reload or switch the underlying async operation
+  /// while keeping the same signal instance.
+  ///
+  /// Example:
+  /// ```dart
+  /// await signal.fetch(FutureSource(fetchData()));
+  /// ```
+  Future<void> fetch(AsyncSource<T> source);
 }

--- a/packages/jolt/test/async_test.dart
+++ b/packages/jolt/test/async_test.dart
@@ -1,7 +1,39 @@
+import "dart:async";
+
 import "package:jolt/extension.dart";
 import "package:jolt/jolt.dart";
 import "package:test/test.dart";
 import "utils.dart";
+
+class ManualAsyncSource<T> extends AsyncSource<T> {
+  final Completer<void> _completer = Completer<void>();
+  void Function(AsyncState<T> state)? _emit;
+  bool _disposed = false;
+
+  @override
+  Future<void> subscribe(void Function(AsyncState<T> state) emit) async {
+    _emit = emit;
+    await _completer.future;
+  }
+
+  void emit(AsyncState<T> state) {
+    _emit?.call(state);
+  }
+
+  void complete() {
+    if (!_completer.isCompleted) {
+      _completer.complete();
+    }
+  }
+
+  @override
+  void dispose() {
+    _disposed = true;
+    complete();
+  }
+
+  bool get isDisposed => _disposed;
+}
 
 void main() {
   group("AsyncState", () {
@@ -155,6 +187,62 @@ void main() {
       asyncSignal.dispose();
       expect(asyncSignal.isDisposed, isTrue);
     });
+
+    test("should fetch a new source from the public AsyncSignal API",
+        () async {
+      final asyncSignal = AsyncSignal<int>(
+        initialValue: const AsyncSuccess(1),
+      );
+
+      await asyncSignal.fetch(FutureSource(Future.value(2)));
+
+      expect(asyncSignal.value, isA<AsyncSuccess<int>>());
+      expect(asyncSignal.data, equals(2));
+    });
+
+    test("should expose AsyncState convenience members on AsyncSignal", () {
+      final error = Exception("Test error");
+      final stackTrace = StackTrace.current;
+      final asyncSignal = AsyncSignal<int>(
+        initialValue: AsyncError(error, stackTrace),
+      );
+
+      expect(asyncSignal.isLoading, isFalse);
+      expect(asyncSignal.isSuccess, isFalse);
+      expect(asyncSignal.isError, isTrue);
+      expect(asyncSignal.data, isNull);
+      expect(asyncSignal.error, same(error));
+      expect(asyncSignal.stackTrace, same(stackTrace));
+      expect(
+        asyncSignal.map(
+          loading: () => "loading",
+          success: (data) => "success: $data",
+          error: (error, stackTrace) => "error: $error",
+        ),
+        equals("error: Exception: Test error"),
+      );
+    });
+
+    test("should ignore stale emissions from previous fetch", () async {
+      final firstSource = ManualAsyncSource<int>();
+      final secondSource = ManualAsyncSource<int>();
+      final asyncSignal = AsyncSignal<int>();
+
+      final firstFetch = asyncSignal.fetch(firstSource);
+      firstSource.emit(const AsyncSuccess(1));
+      expect(asyncSignal.data, equals(1));
+
+      final secondFetch = asyncSignal.fetch(secondSource);
+      secondSource.emit(const AsyncSuccess(2));
+      expect(asyncSignal.data, equals(2));
+
+      firstSource.emit(const AsyncSuccess(99));
+      expect(asyncSignal.data, equals(2));
+
+      firstSource.complete();
+      secondSource.complete();
+      await Future.wait([firstFetch, secondFetch]);
+    });
   });
 
   group("FutureSignal", () {
@@ -247,9 +335,7 @@ void main() {
 
       streamSignal.dispose();
 
-
       await Future.delayed(const Duration(milliseconds: 100));
-
 
       expect(streamSignal.data, isA<int>());
       expect(streamSignal.value, isA<AsyncSuccess<int>>());
@@ -267,6 +353,18 @@ void main() {
       await Future.delayed(const Duration(milliseconds: 1));
 
       asyncSignal.dispose();
+      expect(source.isDisposed, isTrue);
+    });
+
+    test("should dispose active source when AsyncSignal is disposed",
+        () async {
+      final source = ManualAsyncSource<String>();
+      final asyncSignal = AsyncSignal<String>(source: source);
+
+      await Future.delayed(const Duration(milliseconds: 1));
+
+      asyncSignal.dispose();
+
       expect(source.isDisposed, isTrue);
     });
   });


### PR DESCRIPTION
Fix stale fetch emissions overriding newer results, ensure active sources are disposed, and remove outdated async-signal docs