### PR TITLE
fix(jolt): improve reactive graph propagation and disposal

### DIFF
--- a/docs/src/jolt/core/computed.md
+++ b/docs/src/jolt/core/computed.md
@@ -171,8 +171,8 @@ This is particularly useful when implementing custom logic that needs to compare
 
 If you need to manually tell subscribers that it has updated, you can use the `notify()` method. The `notify()` method accepts an optional `force` parameter:
 
-- **`notify(false)` or `notify()`** (soft update): Only notifies subscribers if the computed value actually changed during recomputation. This is the default behavior.
-- **`notify(true)`** (force update): Always notifies subscribers, even if the value hasn't changed.
+- **`notify()` or `notify(true)`** (force update): Always notifies subscribers, even if the value hasn't changed. This is the default behavior.
+- **`notify(false)`** (soft update): Only notifies subscribers if the computed value actually changed during recomputation.
 
 ```dart
 final count = Signal(0);

--- a/docs/src/zh/jolt/core/computed.md
+++ b/docs/src/zh/jolt/core/computed.md
@@ -171,8 +171,8 @@ computed.value; // previousValue 是 0（之前的待处理值）
 
 如果需要手动告诉依赖它的订阅者它更新了，可以使用 `notify()` 方法。`notify()` 方法接受一个可选的 `force` 参数：
 
-- **`notify(false)` 或 `notify()`**（软更新）：只有在计算值在重新计算期间实际改变时才通知订阅者。这是默认行为。
-- **`notify(true)`**（强制更新）：即使值没有改变，也会通知订阅者。
+- **`notify()` 或 `notify(true)`**（强制更新）：即使值没有改变，也会通知订阅者。这是默认行为。
+- **`notify(false)`**（软更新）：只有在计算值在重新计算期间实际改变时才通知订阅者。
 
 ```dart
 final count = Signal(0);

--- a/packages/jolt/lib/src/core/debug.dart
+++ b/packages/jolt/lib/src/core/debug.dart
@@ -553,12 +553,7 @@ abstract final class JoltDevTools {
   }
 
   static bool _isDisposed(ReactiveNode node) {
-    try {
-      // Check if node has isDisposed property (duck typing)
-      return (node as dynamic).isDisposed == true;
-    } catch (e) {
-      return false;
-    }
+    return node.isDisposed;
   }
 
   static dynamic _getNodeValue(ReactiveNode node) {

--- a/packages/jolt/lib/src/core/reactive.dart
+++ b/packages/jolt/lib/src/core/reactive.dart
@@ -2,6 +2,12 @@ import "package:jolt/src/core/debug.dart";
 import "package:meta/meta.dart";
 import "package:shared_interfaces/shared_interfaces.dart";
 
+/// Ported from and adapted from:
+/// https://github.com/stackblitz/alien-signals
+///
+/// This file has been modified to fit Jolt's Dart APIs, runtime behavior, and
+/// project conventions.
+
 part "system.dart";
 
 /// Monotonically increasing counter used to stamp dependency links during

--- a/packages/jolt/lib/src/core/reactive.dart
+++ b/packages/jolt/lib/src/core/reactive.dart
@@ -354,9 +354,8 @@ int getBatchDepth() => batchDepth;
 @pragma("wasm:prefer-inline")
 @pragma("dart2js:prefer-inline")
 bool updateComputed<T>(ComputedReactiveNode<T> computed) {
-  if (computed.flags & ReactiveFlags.disposed != 0) return false;
+  if (computed.isDisposed) return false;
 
-  ++cycle;
   computed
     ..depsTail = null
     ..flags = ReactiveFlags.mutable | ReactiveFlags.recursedCheck;
@@ -403,7 +402,7 @@ bool updateComputed<T>(ComputedReactiveNode<T> computed) {
 @pragma("wasm:prefer-inline")
 @pragma("dart2js:prefer-inline")
 bool updateSignal<T>(SignalReactiveNode<T> signal) {
-  if (signal.flags & ReactiveFlags.disposed != 0) return false;
+  if (signal.isDisposed) return false;
 
   signal.flags &= ReactiveFlags.mutable;
 
@@ -436,7 +435,7 @@ bool updateSignal<T>(SignalReactiveNode<T> signal) {
 @pragma("wasm:prefer-inline")
 @pragma("dart2js:prefer-inline")
 bool updateCustom<T>(ReactiveNode node) {
-  if (node.flags & ReactiveFlags.disposed != 0) return false;
+  if (node.isDisposed) return false;
 
   node.flags = ReactiveFlags.mutable;
 
@@ -496,7 +495,7 @@ bool _removePending(ReactiveNode e, int flags) {
 @pragma("wasm:prefer-inline")
 @pragma("dart2js:prefer-inline")
 void defaultRunEffect(EffectReactiveNode e, void Function() fn) {
-  if (e.flags & ReactiveFlags.disposed != 0) return;
+  if (e.isDisposed) return;
 
   final flags = e.flags;
   if (flags & (ReactiveFlags.dirty) != 0 ||
@@ -578,9 +577,10 @@ void flushEffects() {
 @pragma("wasm:prefer-inline")
 @pragma("dart2js:prefer-inline")
 T getComputed<T>(ComputedReactiveNode<T> computed) {
-  if ((computed.flags & ReactiveFlags.disposed) != 0) {
+  if (computed.isDisposed) {
     return computed.pendingValue as T;
   }
+
   final flags = computed.flags;
   if (flags & ReactiveFlags.dirty != 0 ||
       (flags & ReactiveFlags.pending != 0 &&
@@ -638,7 +638,7 @@ T getComputed<T>(ComputedReactiveNode<T> computed) {
 @pragma("wasm:prefer-inline")
 @pragma("dart2js:prefer-inline")
 void notifyComputed<T>(ComputedReactiveNode<T> computed, [bool force = false]) {
-  if (computed.flags & ReactiveFlags.disposed != 0) return;
+  if (computed.isDisposed) return;
 
   final updated = updateComputed(computed);
 
@@ -677,7 +677,7 @@ void notifyComputed<T>(ComputedReactiveNode<T> computed, [bool force = false]) {
 @pragma("wasm:prefer-inline")
 @pragma("dart2js:prefer-inline")
 T setSignal<T>(SignalReactiveNode<T> signal, T newValue) {
-  if (signal.flags & ReactiveFlags.disposed != 0) return newValue;
+  if (signal.isDisposed) return newValue;
 
   if (signal.pendingValue != (signal.pendingValue = newValue)) {
     signal.flags = ReactiveFlags.mutable | ReactiveFlags.dirty;
@@ -713,6 +713,10 @@ T setSignal<T>(SignalReactiveNode<T> signal, T newValue) {
 @pragma("wasm:prefer-inline")
 @pragma("dart2js:prefer-inline")
 T getSignal<T>(SignalReactiveNode<T> signal) {
+  if (signal.isDisposed) {
+    return signal.cachedValue as T;
+  }
+
   if (signal.flags & (ReactiveFlags.dirty) != 0) {
     if (updateSignal<T>(signal)) {
       final subs = signal.subs;
@@ -754,7 +758,8 @@ T getSignal<T>(SignalReactiveNode<T> signal) {
 @pragma("wasm:prefer-inline")
 @pragma("dart2js:prefer-inline")
 void notifySignal<T>(SignalReactiveNode signal) {
-  if (signal.flags & ReactiveFlags.disposed != 0) return;
+  if (signal.isDisposed) return;
+
   // Mark as changed even if the underlying reference didn't change (e.g. in-place mutations).
   signal.flags = ReactiveFlags.mutable | ReactiveFlags.dirty;
 
@@ -798,7 +803,7 @@ void notifySignal<T>(SignalReactiveNode signal) {
 @pragma("wasm:prefer-inline")
 @pragma("dart2js:prefer-inline")
 void notifyCustom<T>(ReactiveNode node) {
-  if (node.flags & ReactiveFlags.disposed != 0) return;
+  if (node.isDisposed) return;
 
   node.flags = ReactiveFlags.mutable | ReactiveFlags.dirty;
 
@@ -820,6 +825,8 @@ void notifyCustom<T>(ReactiveNode node) {
 @pragma("wasm:prefer-inline")
 @pragma("dart2js:prefer-inline")
 void getCustom(ReactiveNode node) {
+  if (node.isDisposed) return;
+
   var sub = activeSub;
   while (sub != null) {
     if (sub.flags & (ReactiveFlags.mutable | ReactiveFlags.watching) != 0) {
@@ -836,7 +843,7 @@ void getCustom(ReactiveNode node) {
   }());
 }
 
-/// Disposes a reactive node: marks it [ReactiveFlags.disposed], detaches
+/// Disposes a reactive node: marks it inactive, detaches
 /// dependencies/subscribers. The node no longer participates in updates or propagation.
 ///
 /// Parameters:
@@ -855,7 +862,7 @@ void disposeNode(ReactiveNode e) {
 
   e
     ..depsTail = null
-    ..flags = ReactiveFlags.disposed;
+    ..flags = ReactiveFlags.none;
   purgeDeps(e);
   final sub = e.subs;
   if (sub != null) {

--- a/packages/jolt/lib/src/core/reactive.dart
+++ b/packages/jolt/lib/src/core/reactive.dart
@@ -110,9 +110,18 @@ bool updateNode(ReactiveNode node) {
   final result = switch (node) {
     ComputedReactiveNode() => updateComputed(node),
     SignalReactiveNode() => updateSignal(node),
+    EffectScopeReactiveNode() => _updateEffectScope(node),
     _ => updateCustom(node),
   };
   return result;
+}
+
+@pragma("vm:prefer-inline")
+@pragma("wasm:prefer-inline")
+@pragma("dart2js:prefer-inline")
+bool _updateEffectScope(EffectScopeReactiveNode node) {
+  node.flags = ReactiveFlags.mutable;
+  return true;
 }
 
 /// Enqueues an [EffectReactiveNode] chain for execution.
@@ -725,14 +734,9 @@ T getSignal<T>(SignalReactiveNode<T> signal) {
       }
     }
   }
-  var sub = activeSub;
-  while (sub != null) {
-    if (sub.flags & (ReactiveFlags.mutable | ReactiveFlags.watching) != 0) {
-      link(signal, sub, cycle);
-
-      break;
-    }
-    sub = sub.subs?.sub;
+  final sub = activeSub;
+  if (sub != null) {
+    link(signal, sub, cycle);
   }
 
   assert(() {

--- a/packages/jolt/lib/src/core/reactive.dart
+++ b/packages/jolt/lib/src/core/reactive.dart
@@ -1015,8 +1015,7 @@ abstract interface class Notifiable {
   ///
   /// Parameters:
   /// - [force]: If `true`, forces notification even if the value hasn't changed.
-  ///   The default value depends on the implementation (e.g., `false` for
-  ///   [Computed], `true` for [Signal]).
+  ///   Defaults to `true`; pass `false` explicitly for a soft update.
   ///
   /// Example:
   /// ```dart
@@ -1025,10 +1024,10 @@ abstract interface class Notifiable {
   /// list.notify(); // Force subscribers to update
   ///
   /// final computed = Computed(() => expensiveCalculation());
-  /// computed.notify(); // Soft update: only notifies if value changed
-  /// computed.notify(true); // Force update: always notifies subscribers
+  /// computed.notify(); // Force update: always notifies subscribers
+  /// computed.notify(false); // Soft update: only notifies if value changed
   /// ```
-  void notify([bool force]);
+  void notify([bool force = true]);
 }
 
 /// Interface for writable reactive values.

--- a/packages/jolt/lib/src/core/reactive.dart
+++ b/packages/jolt/lib/src/core/reactive.dart
@@ -514,7 +514,7 @@ void defaultRunEffect(EffectReactiveNode e, void Function() fn) {
       e.flags &= ~ReactiveFlags.recursedCheck;
       purgeDeps(e);
     }
-  } else {
+  } else if (e.flags != ReactiveFlags.none) {
     e.flags = ReactiveFlags.watching;
   }
 }

--- a/packages/jolt/lib/src/core/reactive.dart
+++ b/packages/jolt/lib/src/core/reactive.dart
@@ -21,6 +21,8 @@ part "system.dart";
 /// ```
 int cycle = 0;
 
+int runDepth = 0;
+
 /// Current nesting depth of [`startBatch`]/[`endBatch`] calls.
 ///
 /// Example:
@@ -371,6 +373,8 @@ bool updateComputed<T>(ComputedReactiveNode<T> computed) {
   final prevSub = setActiveSub(computed);
 
   try {
+    ++cycle;
+    ++runDepth;
     final oldValue = computed.pendingValue;
     final newValue = computed.getter();
     final equals = computed.equals == null
@@ -387,6 +391,7 @@ bool updateComputed<T>(ComputedReactiveNode<T> computed) {
     }());
     return true;
   } finally {
+    --runDepth;
     activeSub = prevSub;
     computed.flags &= ~ReactiveFlags.recursedCheck;
     purgeDeps(computed);
@@ -509,7 +514,6 @@ void defaultRunEffect(EffectReactiveNode e, void Function() fn) {
   final flags = e.flags;
   if (flags & (ReactiveFlags.dirty) != 0 ||
       (flags & (ReactiveFlags.pending) != 0 && checkDirty(e.deps!, e))) {
-    ++cycle;
     e
       ..depsTail = null
       ..flags = ReactiveFlags.watching | ReactiveFlags.recursedCheck;
@@ -517,8 +521,11 @@ void defaultRunEffect(EffectReactiveNode e, void Function() fn) {
     // only effect and watcher;
     final prevSub = setActiveSub(e);
     try {
+      ++cycle;
+      ++runDepth;
       fn();
     } finally {
+      --runDepth;
       activeSub = prevSub;
       e.flags &= ~ReactiveFlags.recursedCheck;
       purgeDeps(e);
@@ -605,8 +612,10 @@ T getComputed<T>(ComputedReactiveNode<T> computed) {
     computed.flags = ReactiveFlags.mutable | ReactiveFlags.recursedCheck;
     final prevSub = setActiveSub(computed);
     try {
+      ++runDepth;
       computed.pendingValue = computed.getter();
     } finally {
+      --runDepth;
       activeSub = prevSub;
       computed.flags &= ~ReactiveFlags.recursedCheck;
     }
@@ -693,7 +702,7 @@ T setSignal<T>(SignalReactiveNode<T> signal, T newValue) {
 
     final subs = signal.subs;
     if (subs != null) {
-      propagate(subs);
+      propagate(subs, runDepth > 0);
       if (batchDepth == 0) {
         flushEffects();
       }
@@ -771,7 +780,7 @@ void notifySignal<T>(SignalReactiveNode signal) {
 
   final subs = signal.subs;
   if (subs != null) {
-    propagate(subs);
+    propagate(subs, runDepth > 0);
     shallowPropagate(subs);
     if (batchDepth == 0) {
       flushEffects();
@@ -813,7 +822,7 @@ void notifyCustom<T>(ReactiveNode node) {
 
   final subs = node.subs;
   if (subs != null) {
-    propagate(subs);
+    propagate(subs, runDepth > 0);
     if (batchDepth == 0) {
       flushEffects();
     }
@@ -929,7 +938,7 @@ T trigger<T>(T Function() fn) {
       link = unlink(link, sub);
       final subs = dep.subs;
       if (subs != null) {
-        propagate(subs);
+        propagate(subs, runDepth > 0);
         shallowPropagate(subs);
       }
     }

--- a/packages/jolt/lib/src/core/reactive.dart
+++ b/packages/jolt/lib/src/core/reactive.dart
@@ -913,17 +913,18 @@ void purgeDeps(ReactiveNode sub) {
 T trigger<T>(T Function() fn) {
   final sub = _DummyEffectNode(flags: ReactiveFlags.watching);
   final prevSub = setActiveSub(sub);
+
   try {
     return fn();
   } finally {
     activeSub = prevSub;
+    sub.flags = ReactiveFlags.none;
     var link = sub.deps;
     while (link != null) {
       final dep = link.dep;
       link = unlink(link, sub);
       final subs = dep.subs;
       if (subs != null) {
-        sub.flags = ReactiveFlags.none;
         propagate(subs);
         shallowPropagate(subs);
       }

--- a/packages/jolt/lib/src/core/system.dart
+++ b/packages/jolt/lib/src/core/system.dart
@@ -325,7 +325,7 @@ Link? unlink(Link link, [ReactiveNode? sub]) {
 /// final signalNode = CustomSignalNode<int>(0);
 /// propagate(signalNode.subs!);
 /// ```
-void propagate(Link theLink) {
+void propagate(Link theLink, bool innerWrite) {
   Link? link = theLink;
   var next = link.nextSub;
   Stack<Link?>? stack;
@@ -344,6 +344,9 @@ void propagate(Link theLink) {
                 ReactiveFlags.pending) ==
         0) {
       sub.flags = flags | ReactiveFlags.pending;
+      if (innerWrite) {
+        sub.flags |= ReactiveFlags.recursed;
+      }
     } else if (flags & (ReactiveFlags.recursedCheck | ReactiveFlags.recursed) ==
         0) {
       flags = ReactiveFlags.none;
@@ -352,6 +355,7 @@ void propagate(Link theLink) {
     } else if (flags & (ReactiveFlags.dirty | ReactiveFlags.pending) == 0 &&
         isValidLink(link, sub)) {
       sub.flags = flags | (ReactiveFlags.recursed | ReactiveFlags.pending);
+
       flags &= ReactiveFlags.mutable;
     } else {
       flags = ReactiveFlags.none;

--- a/packages/jolt/lib/src/core/system.dart
+++ b/packages/jolt/lib/src/core/system.dart
@@ -454,10 +454,10 @@ bool checkDirty(Link theLink, ReactiveNode sub) {
       link = stack!.value;
       stack = stack.prev;
       if (dirty) {
-        final subs = sub.subs!;
+        final subs = sub.subs;
         if (updateNode(sub)) {
-          if (subs.nextSub != null) {
-            shallowPropagate(subs);
+          if (subs?.nextSub != null) {
+            shallowPropagate(subs!);
           }
           sub = link!.sub;
           continue;

--- a/packages/jolt/lib/src/core/system.dart
+++ b/packages/jolt/lib/src/core/system.dart
@@ -47,6 +47,9 @@ class ReactiveNode {
 
   /// Reactive flags for this node.
   int flags;
+
+  /// Whether this node has been disposed.
+  bool get isDisposed => false;
 }
 
 /// Link between reactive nodes in the dependency graph.
@@ -175,12 +178,6 @@ abstract final class ReactiveFlags {
 
   /// Node is pending update.
   static const pending = 1 << 5;
-
-  /// Node has been disposed.
-  ///
-  /// When set, update and propagation are skipped for this node.
-  /// [none] is the special initial state; [disposed] is set when the node is disposed.
-  static const disposed = 1 << 6;
 }
 
 /// Abstract reactive system for managing dependency tracking.

--- a/packages/jolt/lib/src/core/system.dart
+++ b/packages/jolt/lib/src/core/system.dart
@@ -323,7 +323,7 @@ Link? unlink(Link link, [ReactiveNode? sub]) {
 /// Example:
 /// ```dart
 /// final signalNode = CustomSignalNode<int>(0);
-/// propagate(signalNode.subs!);
+/// propagate(signalNode.subs!, false);
 /// ```
 void propagate(Link theLink, bool innerWrite) {
   Link? link = theLink;

--- a/packages/jolt/lib/src/core/system.dart
+++ b/packages/jolt/lib/src/core/system.dart
@@ -286,11 +286,7 @@ void link(ReactiveNode dep, ReactiveNode sub, int version) {
 Link? unlink(Link link, [ReactiveNode? sub]) {
   sub ??= link.sub;
 
-  final dep = link.dep;
-  final prevDep = link.prevDep;
-  final nextDep = link.nextDep;
-  final nextSub = link.nextSub;
-  final prevSub = link.prevSub;
+  final Link(:dep, :prevDep, :nextDep, :nextSub, :prevSub) = link;
   if (nextDep != null) {
     nextDep.prevDep = prevDep;
   } else {
@@ -426,8 +422,8 @@ bool checkDirty(Link theLink, ReactiveNode sub) {
       dirty = true;
     } else if (flags & (ReactiveFlags.mutable | ReactiveFlags.dirty) ==
         (ReactiveFlags.mutable | ReactiveFlags.dirty)) {
+      final subs = dep.subs!;
       if (updateNode(dep)) {
-        final subs = dep.subs!;
         if (subs.nextSub != null) {
           shallowPropagate(subs);
         }
@@ -435,9 +431,7 @@ bool checkDirty(Link theLink, ReactiveNode sub) {
       }
     } else if (flags & (ReactiveFlags.mutable | ReactiveFlags.pending) ==
         (ReactiveFlags.mutable | ReactiveFlags.pending)) {
-      if (link.nextSub != null || link.prevSub != null) {
-        stack = Stack(value: link, prev: stack);
-      }
+      stack = Stack(value: link, prev: stack);
       link = dep.deps;
       sub = dep;
       ++checkDepth;
@@ -453,18 +447,13 @@ bool checkDirty(Link theLink, ReactiveNode sub) {
     }
 
     while (checkDepth-- != 0) {
-      final firstSub = sub.subs!;
-      final hasMultipleSubs = firstSub.nextSub != null;
-      if (hasMultipleSubs) {
-        link = stack!.value;
-        stack = stack.prev;
-      } else {
-        link = firstSub;
-      }
+      link = stack!.value;
+      stack = stack.prev;
       if (dirty) {
+        final subs = sub.subs!;
         if (updateNode(sub)) {
-          if (hasMultipleSubs) {
-            shallowPropagate(firstSub);
+          if (subs.nextSub != null) {
+            shallowPropagate(subs);
           }
           sub = link!.sub;
           continue;
@@ -481,7 +470,7 @@ bool checkDirty(Link theLink, ReactiveNode sub) {
       }
     }
 
-    return dirty;
+    return dirty && sub.flags != ReactiveFlags.none;
   } while (true);
 }
 

--- a/packages/jolt/lib/src/jolt/base.dart
+++ b/packages/jolt/lib/src/jolt/base.dart
@@ -89,7 +89,7 @@ abstract interface class DisposableNode implements Disposable {
 
 /// Mixin providing base disposal functionality for reactive nodes.
 ///
-/// Sets [ReactiveFlags.disposed] so the node is no longer reactive.
+/// Marks the node as disposed so it is no longer reactive.
 /// Implements common disposal logic and calls [onDispose] for custom cleanup.
 ///
 /// Example:
@@ -103,17 +103,17 @@ abstract interface class DisposableNode implements Disposable {
 /// ```
 mixin DisposableNodeMixin
     implements DisposableNode, ChainedDisposable, ReactiveNode {
+  bool _isDisposed = false;
+
   /// Whether this node has been disposed.
   @override
-  bool get isDisposed => flags == ReactiveFlags.disposed;
+  bool get isDisposed => _isDisposed;
 
   @override
   @mustCallSuper
   void dispose() {
     if (isDisposed) return;
-    flags = ReactiveFlags.disposed;
-    // allow unawaited futures
-    // ignore: discarded_futures
+    _isDisposed = true;
     onDispose();
 
     JFinalizer.disposeObject(this);

--- a/packages/jolt/lib/src/jolt/collection/list_signal.dart
+++ b/packages/jolt/lib/src/jolt/collection/list_signal.dart
@@ -148,27 +148,27 @@ mixin ListSignalMixin<E>
     final oldValue = peek[index];
     peek[index] = value;
     if (oldValue != value) {
-      notify(true);
+      notify();
     }
   }
 
   @override
   void add(E value) {
     peek.add(value);
-    notify(true);
+    notify();
   }
 
   @override
   void addAll(Iterable<E> iterable) {
     peek.addAll(iterable);
-    notify(true);
+    notify();
   }
 
   @override
   void clear() {
     if (peek.isNotEmpty) {
       peek.clear();
-      notify(true);
+      notify();
     }
   }
 
@@ -184,20 +184,20 @@ mixin ListSignalMixin<E>
       peek[i] = value;
     }
     if (needNotify) {
-      notify(true);
+      notify();
     }
   }
 
   @override
   void insert(int index, E element) {
     peek.insert(index, element);
-    notify(true);
+    notify();
   }
 
   @override
   void insertAll(int index, Iterable<E> iterable) {
     peek.insertAll(index, iterable);
-    notify(true);
+    notify();
   }
 
   @override
@@ -252,7 +252,7 @@ mixin ListSignalMixin<E>
 
     peek.replaceRange(start, end, replacements);
 
-    if (needNotify) notify(true);
+    if (needNotify) notify();
   }
 
   @override
@@ -283,7 +283,7 @@ mixin ListSignalMixin<E>
 
     peek.setAll(index, iterable);
 
-    if (needNotify) notify(true);
+    if (needNotify) notify();
   }
 
   @override
@@ -309,14 +309,14 @@ mixin ListSignalMixin<E>
 
     peek.setRange(start, end, iterable, skipCount);
 
-    if (changed) notify(true);
+    if (changed) notify();
   }
 
   @override
   void shuffle([Random? random]) {
     if (peek.isNotEmpty) {
       peek.shuffle(random);
-      notify(true);
+      notify();
     }
   }
 
@@ -324,7 +324,7 @@ mixin ListSignalMixin<E>
   void sort([int Function(E a, E b)? compare]) {
     if (peek.isNotEmpty) {
       peek.sort(compare);
-      notify(true);
+      notify();
     }
   }
 
@@ -333,7 +333,7 @@ mixin ListSignalMixin<E>
     final oldValue = peek.first;
     if (oldValue != val) {
       peek.first = val;
-      notify(true);
+      notify();
     }
   }
 
@@ -342,7 +342,7 @@ mixin ListSignalMixin<E>
     final oldValue = peek.last;
     if (oldValue != val) {
       peek.last = val;
-      notify(true);
+      notify();
     }
   }
 
@@ -350,7 +350,7 @@ mixin ListSignalMixin<E>
   set length(int value) {
     if (peek.length != value) {
       peek.length = value;
-      notify(true);
+      notify();
     }
   }
 
@@ -361,7 +361,7 @@ mixin ListSignalMixin<E>
     final originLength = peek.length;
     final result = fn();
     if (originLength != peek.length) {
-      notify(true);
+      notify();
     }
     return result;
   }

--- a/packages/jolt/lib/src/jolt/collection/map_signal.dart
+++ b/packages/jolt/lib/src/jolt/collection/map_signal.dart
@@ -94,7 +94,7 @@ mixin MapSignalMixin<K, V>
     final needNotify = !peek.containsKey(key) || peek[key] != value;
     peek[key] = value;
     if (needNotify) {
-      notify(true);
+      notify();
     }
   }
 
@@ -113,7 +113,7 @@ mixin MapSignalMixin<K, V>
     });
 
     if (needNotify) {
-      notify(true);
+      notify();
     }
   }
 
@@ -133,7 +133,7 @@ mixin MapSignalMixin<K, V>
     }
 
     if (needNotify) {
-      notify(true);
+      notify();
     }
   }
 
@@ -146,7 +146,7 @@ mixin MapSignalMixin<K, V>
       return;
     } else {
       peek.clear();
-      notify(true);
+      notify();
     }
   }
 
@@ -161,7 +161,7 @@ mixin MapSignalMixin<K, V>
       return peek[key] as V;
     }
     final result = peek[key] = ifAbsent();
-    notify(true);
+    notify();
     return result;
   }
 
@@ -173,7 +173,7 @@ mixin MapSignalMixin<K, V>
   V? remove(Object? key) {
     if (peek.containsKey(key)) {
       final v = peek.remove(key);
-      notify(true);
+      notify();
       return v;
     } else {
       return peek.remove(key);
@@ -192,13 +192,13 @@ mixin MapSignalMixin<K, V>
       final oldValue = peek[key];
       final newValue = peek[key] = update(oldValue as V);
       if (oldValue != newValue) {
-        notify(true);
+        notify();
       }
       return newValue;
     }
     if (ifAbsent != null) {
       final result = peek[key] = ifAbsent();
-      notify(true);
+      notify();
       return result;
     }
     throw ArgumentError.value(key, "key", "Key not in map.");
@@ -219,7 +219,7 @@ mixin MapSignalMixin<K, V>
       }
     }
     if (needNotify) {
-      notify(true);
+      notify();
     }
   }
 
@@ -237,7 +237,7 @@ mixin MapSignalMixin<K, V>
       peek.remove(key);
     }
     if (keysToRemove.isNotEmpty) {
-      notify(true);
+      notify();
     }
   }
 }

--- a/packages/jolt/lib/src/jolt/collection/set_signal.dart
+++ b/packages/jolt/lib/src/jolt/collection/set_signal.dart
@@ -48,7 +48,7 @@ mixin SetSignalMixin<E>
   bool remove(Object? element) {
     final result = peek.remove(element);
     if (result) {
-      notify(true);
+      notify();
     }
     return result;
   }
@@ -237,7 +237,7 @@ mixin SetSignalMixin<E>
   bool add(E element) {
     final result = peek.add(element);
     if (result) {
-      notify(true);
+      notify();
     }
     return result;
   }
@@ -298,7 +298,7 @@ mixin SetSignalMixin<E>
     final originLength = peek.length;
     final result = fn();
     if (originLength != peek.length) {
-      notify(true);
+      notify();
     }
     return result;
   }

--- a/packages/jolt/lib/src/jolt/computed.dart
+++ b/packages/jolt/lib/src/jolt/computed.dart
@@ -157,7 +157,7 @@ class ComputedImpl<T> extends ComputedReactiveNode<T>
   ///
   /// Parameters:
   /// - [force]: If `true`, forces notification even if the value hasn't changed
-  ///   (soft update when `false`, force update when `true`). Defaults to `false`.
+  ///   (soft update when `false`, force update when `true`). Defaults to `true`.
   ///
   /// When `force` is `false` (soft update), subscribers are only notified if
   /// the computed value actually changed. When `force` is `true` (force update),
@@ -166,14 +166,14 @@ class ComputedImpl<T> extends ComputedReactiveNode<T>
   /// Example:
   /// ```dart
   /// final computed = Computed(() => expensiveCalculation());
-  /// computed.notify(); // Soft update: only notifies if value changed
-  /// computed.notify(true); // Force update: always notifies subscribers
+  /// computed.notify(); // Force update: always notifies subscribers
+  /// computed.notify(false); // Soft update: only notifies if value changed
   /// ```
   @pragma("vm:prefer-inline")
   @pragma("wasm:prefer-inline")
   @pragma("dart2js:prefer-inline")
   @override
-  void notify([bool force = false]) {
+  void notify([bool force = true]) {
     notifyComputed(this, force);
   }
 

--- a/packages/jolt/lib/src/jolt/effect.dart
+++ b/packages/jolt/lib/src/jolt/effect.dart
@@ -96,7 +96,7 @@ class EffectScopeImpl extends EffectScopeReactiveNode
   ///   });
   /// ```
   EffectScopeImpl({bool? detach, JoltDebugOption? debug})
-      : super(flags: ReactiveFlags.none) {
+      : super(flags: ReactiveFlags.mutable) {
     assert(() {
       JoltDebug.create(this, debug);
       return true;
@@ -507,7 +507,10 @@ class WatcherImpl<T> extends EffectReactiveNode
   /// ```
   /// {@endtemplate}
   WatcherImpl(this.sourcesFn, this.fn,
-      {bool immediately = false, this.when, bool? detach, JoltDebugOption? debug})
+      {bool immediately = false,
+      this.when,
+      bool? detach,
+      JoltDebugOption? debug})
       : super(flags: ReactiveFlags.watching) {
     assert(() {
       JoltDebug.create(this, debug);

--- a/packages/jolt/lib/src/jolt/effect.dart
+++ b/packages/jolt/lib/src/jolt/effect.dart
@@ -283,8 +283,10 @@ class EffectImpl extends EffectReactiveNode
     if (!lazy) {
       final prevSub = setActiveSub(this);
       try {
+        ++runDepth;
         _effectFn();
       } finally {
+        --runDepth;
         setActiveSub(prevSub);
         flags &= ~ReactiveFlags.recursedCheck;
       }

--- a/packages/jolt/lib/src/utils/delegated.dart
+++ b/packages/jolt/lib/src/utils/delegated.dart
@@ -105,17 +105,20 @@ class DelegatedReadonlySignal<T> implements ReadonlySignal<T> {
 
   final DelegatedRefCountHelper<ReadonlySignal<T>> delegated;
   Disposer? _releaseDisposer;
+  late final T _disposedValue;
 
   @override
-  T get peek => delegated.source.peek;
+  T get peek => _isDisposed ? _disposedValue : delegated.source.peek;
 
   @override
   T get value {
+    if (_isDisposed) return _disposedValue;
     return delegated.source.value;
   }
 
   @override
   void notify([bool force = false]) {
+    if (_isDisposed) return;
     delegated.source.notify(force);
   }
 
@@ -124,6 +127,7 @@ class DelegatedReadonlySignal<T> implements ReadonlySignal<T> {
   @override
   void dispose() {
     if (_isDisposed) return;
+    _disposedValue = delegated.source.peek;
     _isDisposed = true;
 
     delegated.release();
@@ -164,22 +168,26 @@ class DelegatedSignal<T> implements Signal<T> {
 
   final DelegatedRefCountHelper<Signal<T>> delegated;
   Disposer? _releaseDisposer;
+  late final T _disposedValue;
 
   @override
   set value(T value) {
+    if (_isDisposed) return;
     delegated.source.value = value;
   }
 
   @override
-  T get peek => delegated.source.peek;
+  T get peek => _isDisposed ? _disposedValue : delegated.source.peek;
 
   @override
   T get value {
+    if (_isDisposed) return _disposedValue;
     return delegated.source.value;
   }
 
   @override
   void notify([bool force = false]) {
+    if (_isDisposed) return;
     delegated.source.notify(force);
   }
 
@@ -188,6 +196,7 @@ class DelegatedSignal<T> implements Signal<T> {
   @override
   void dispose() {
     if (_isDisposed) return;
+    _disposedValue = delegated.source.peek;
     _isDisposed = true;
 
     delegated.release();

--- a/packages/jolt/lib/src/utils/delegated.dart
+++ b/packages/jolt/lib/src/utils/delegated.dart
@@ -117,7 +117,7 @@ class DelegatedReadonlySignal<T> implements ReadonlySignal<T> {
   }
 
   @override
-  void notify([bool force = false]) {
+  void notify([bool force = true]) {
     if (_isDisposed) return;
     delegated.source.notify(force);
   }
@@ -186,7 +186,7 @@ class DelegatedSignal<T> implements Signal<T> {
   }
 
   @override
-  void notify([bool force = false]) {
+  void notify([bool force = true]) {
     if (_isDisposed) return;
     delegated.source.notify(force);
   }

--- a/packages/jolt/lib/src/utils/writable.dart
+++ b/packages/jolt/lib/src/utils/writable.dart
@@ -104,7 +104,7 @@ class _ComputedWrapperImpl<T> implements Computed<T> {
   bool get isDisposed => root.isDisposed;
 
   @override
-  void notify([bool force = false]) => root.notify(force);
+  void notify([bool force = true]) => root.notify(force);
 
   @override
   T get peekCached => root.peekCached;
@@ -162,5 +162,5 @@ class _ReadonlySignalWrapperImpl<T> implements ReadonlySignal<T> {
   bool get isDisposed => root.isDisposed;
 
   @override
-  void notify([bool force = false]) => root.notify(force);
+  void notify([bool force = true]) => root.notify(force);
 }

--- a/packages/jolt/test/alien/issue_105_test.dart
+++ b/packages/jolt/test/alien/issue_105_test.dart
@@ -1,0 +1,91 @@
+import 'package:test/test.dart';
+
+import 'common.dart';
+
+void main() {
+  group("issue 105", () {
+    test('#105 signal and computed should link to the same node in effectScope',
+        () {
+      final a = signal(0);
+      final b = computed(() => 0);
+      var triggers = 0;
+
+      effect(() {
+        triggers += 1;
+        effectScope(() {
+          effectScope(() {
+            a();
+            b();
+          });
+        });
+      });
+
+      expect(triggers, 1);
+      a(a() + 1, true);
+      expect(triggers, 2);
+      trigger(b);
+      expect(triggers, 3);
+    });
+
+    test(
+        '#105 effect should respond to both signal and computed changes through scope',
+        () {
+      final s = signal(0);
+      final c = computed(() => s() * 2);
+      var triggers = 0;
+
+      effect(() {
+        triggers += 1;
+        effectScope(() {
+          s();
+          c();
+        });
+      });
+
+      expect(triggers, 1);
+
+      s(1, true);
+      expect(triggers, 2);
+
+      trigger(c);
+      expect(triggers, 3);
+    });
+
+    test('#105 scope should respond to consecutive signal updates', () {
+      final s = signal(0);
+      var triggers = 0;
+
+      effect(() {
+        triggers += 1;
+        effectScope(() {
+          s();
+        });
+      });
+
+      expect(triggers, 1);
+      s(1, true);
+      expect(triggers, 2);
+      s(2, true);
+      expect(triggers, 3);
+    });
+
+    test('#105 computed in standalone scope should cache and clean up', () {
+      final s = signal(0);
+      var computeCount = 0;
+
+      final dispose = effectScope(() {
+        final c = computed(() {
+          computeCount++;
+          return s();
+        });
+        expect(c(), 0);
+        expect(c(), 0);
+      });
+
+      // Computed should cache (only 1 evaluation, not 2)
+      expect(computeCount, 1);
+
+      dispose();
+    });
+  });
+}

--- a/packages/jolt/test/alien/issue_109_test.dart
+++ b/packages/jolt/test/alien/issue_109_test.dart
@@ -261,7 +261,11 @@ void main() {
           }
           return s();
         }); // disposes mid-update, value changes
-        final b = computed(() => (a(), a2(), 0)); // reads a before a2
+        final b = computed(() {
+          a();
+          a2();
+          return 0;
+        }); // reads a before a2
         dispose = effect(() {
           b();
         });

--- a/packages/jolt/test/alien/issue_109_test.dart
+++ b/packages/jolt/test/alien/issue_109_test.dart
@@ -17,7 +17,7 @@ void main() {
       dispose = effect(() {
         b();
       });
-      s(true);
+      s(true, true);
     });
 
     group('#109 edge', () {
@@ -251,7 +251,10 @@ void main() {
       test('#109 variant - dep.subs undefined at line 190', () {
         final s = signal(0);
         late void Function() dispose;
-        final a = computed(() => (s(), 0)); // value never changes
+        final a = computed(() {
+          s();
+          return 0;
+        }); // value never changes
         final a2 = computed(() {
           if (s() != 0) {
             dispose();

--- a/packages/jolt/test/alien/issue_109_test.dart
+++ b/packages/jolt/test/alien/issue_109_test.dart
@@ -1,0 +1,269 @@
+import "package:test/test.dart";
+
+import "common.dart";
+
+/// Regression for graph mutations during [checkDirty] / [updateNode], aligned
+/// with alien-signals #109 ([ad52894](https://github.com/stackblitz/alien-signals/commit/ad5289456e06759b85cc170fa53f046c34459287)).
+void main() {
+  group("issue 109", () {
+    test('#109', () {
+      final s = signal(false);
+      late void Function() dispose;
+      final a = computed(() {
+        if (s()) dispose();
+        return 0;
+      });
+      final b = computed(() => a());
+      dispose = effect(() {
+        b();
+      });
+      s(true);
+    });
+
+    group('#109 edge', () {
+// (1) Side-effect after the dispose-trigger inside the effect body
+//     should still run, just like in any other JS function — disposing
+//     swaps the .fn property but the closure already on the stack must
+//     finish executing.
+      test('self-dispose inside effect: code after dispose() still runs', () {
+        final s = signal(0);
+        late void Function() dispose;
+        final stages = <String>[];
+
+        dispose = effect(() {
+          stages.add('start');
+          s();
+          if (s() == 1) {
+            dispose();
+            stages.add('after-dispose');
+          }
+          stages.add('end');
+        });
+
+        expect(stages, equals(['start', 'end']));
+        s(1, true);
+        expect(
+            stages,
+            equals([
+              'start', 'end', // initial run
+              'start', 'after-dispose',
+              'end', // re-run; the fn body must finish
+            ]));
+      });
+
+// (2) When dispose is triggered from *another* node's update (the
+//     #109 path), the swapped fn replaces the user fn before run() calls
+//     it — so the side-effect inside the user fn is never invoked.
+//     This documents that this run is *skipped*, not just suppressed.
+      test('disposed-by-other-node effect: scheduled run is skipped entirely',
+          () {
+        final s = signal(0);
+        late void Function() dispose;
+        var bodyRuns = 0;
+
+        final a = computed(() {
+          if (s() == 1) dispose();
+          return s();
+        });
+
+        dispose = effect(() {
+          a();
+          bodyRuns++;
+        });
+        effect(() {
+          a();
+        });
+
+        expect(bodyRuns, 1);
+        s(1);
+        // The flush queued e1 because of the propagation; if e1 had been
+        // disposed *between flushes*, this run wouldn't have been scheduled.
+        // The fix-by-fn-swap turns the scheduled run into a no-op.
+        expect(bodyRuns, 1);
+      });
+
+// (3) After being disposed mid-flush, the effect's graph state should
+//     be clean: no deps, not Watching, no subs — otherwise future
+//     propagations would still walk through it.
+      test('disposed effect: graph state is fully cleaned up', () {
+        final s = signal(0);
+        late void Function() dispose;
+        ReactiveNode? e1Node;
+
+        final a = computed(() {
+          if (s() == 1) dispose();
+          return s();
+        });
+
+        dispose = effect(() {
+          e1Node ??= getActiveSub();
+          a();
+        });
+        effect(() {
+          a();
+        });
+
+        s(1, true);
+
+        expect(e1Node, isNotNull);
+        expect(e1Node!.deps, isNull);
+        expect(e1Node!.flags & ReactiveFlags.watching, 0);
+      });
+    });
+
+    group('#109 leak', () {
+      test('disposed effect should not be re-notified on later updates', () {
+        final s = signal(0);
+        late void Function() dispose1;
+        var e1runs = 0;
+
+        final a = computed(() {
+          if (s() == 1) dispose1();
+          return s();
+        });
+
+        dispose1 = effect(() {
+          a();
+          e1runs++;
+        });
+        effect(() {
+          a();
+        });
+
+        expect(e1runs, 1);
+        s(1, true);
+        expect(e1runs, 1);
+
+        // If e1 was actually disposed, further signal changes shouldn't
+        // involve it at all. With the fn-swap fix, e1 stays subscribed to `a`
+        // and gets notified each time, even though fn is now a no-op.
+        s(2, true);
+        s(3, true);
+        s(4, true);
+        expect(e1runs, 1);
+      });
+    });
+
+    group('#109 scope', () {
+// Same shape as issue_109.spec.ts, but the dispose target is an
+// effectScope instead of an effect. effectScopeOper has no defer
+// branch in the current fix, so unwatched() cascades immediately and
+// the original crash should still reproduce.
+      test('#109 scope-variant: dispose effectScope during computed update',
+          () {
+        final s = signal(false);
+        late void Function() disposeScope;
+
+        final a = computed(() {
+          if (s()) disposeScope();
+          return 0;
+        });
+        final b = computed(() => a());
+
+        disposeScope = effectScope(() {
+          effect(() {
+            b();
+          });
+        });
+
+        s(true, true);
+      });
+    });
+
+    group('#109 shallow', () {
+      test('#109 shallowPropagate walks stale link after sibling disposal', () {
+        final s = signal(0);
+        late void Function() dispose1;
+        var e2Value = -1;
+
+        final a = computed(() {
+          if (s() == 1) dispose1();
+          return s();
+        });
+
+        dispose1 = effect(() {
+          a();
+        });
+        effect(() {
+          e2Value = a();
+        });
+
+        expect(e2Value, 0);
+        s(1, true);
+        expect(e2Value, 1);
+      });
+
+      test('#109 shallowPropagate walks stale link with 3 subscribers', () {
+        final s = signal(0);
+        late void Function() dispose1;
+        var e2Value = -1;
+        var e3Value = -1;
+
+        final a = computed(() {
+          if (s() == 1) dispose1();
+          return s();
+        });
+
+        dispose1 = effect(() {
+          a();
+        });
+        effect(() {
+          e2Value = a();
+        });
+        effect(() {
+          e3Value = a();
+        });
+
+        expect(e2Value, 0);
+        expect(e3Value, 0);
+        s(1, true);
+        expect(e2Value, 1);
+        expect(e3Value, 1);
+      });
+    });
+
+    group('#109 stale', () {
+      test('#109 stale-link: disposed effect still runs', () {
+        final s = signal(0);
+        late void Function() dispose1;
+        var e1runs = 0;
+
+        final a = computed(() {
+          if (s() == 1) dispose1();
+          return s();
+        });
+
+        dispose1 = effect(() {
+          a();
+          e1runs++;
+        });
+        effect(() {
+          a();
+        }); // second subscriber keeps `a` alive
+
+        expect(e1runs, 1);
+        s(1, true);
+        expect(e1runs, 1); // disposed during update(a); should not re-run
+      });
+    });
+
+    group('#109 variant', () {
+      test('#109 variant - dep.subs undefined at line 190', () {
+        final s = signal(0);
+        late void Function() dispose;
+        final a = computed(() => (s(), 0)); // value never changes
+        final a2 = computed(() {
+          if (s() != 0) {
+            dispose();
+          }
+          return s();
+        }); // disposes mid-update, value changes
+        final b = computed(() => (a(), a2(), 0)); // reads a before a2
+        dispose = effect(() {
+          b();
+        });
+        s(1, true);
+      });
+    });
+  });
+}

--- a/packages/jolt/test/alien/issue_99_test.dart
+++ b/packages/jolt/test/alien/issue_99_test.dart
@@ -1,0 +1,31 @@
+import 'package:test/test.dart';
+
+import 'common.dart';
+
+void main() {
+  group("issue 99", () {
+    test('#99 consecutive inner resets through computed chain', () {
+      final s = signal(0);
+      final c = computed(() => s());
+      var runs = 0;
+
+      effect(() {
+        runs++;
+        if (c() > 0) {
+          s(0, true);
+        }
+      });
+
+      expect(runs, 1);
+      s(1, true);
+      expect(s(), 0);
+      expect(runs, 2);
+      s(2, true);
+      expect(s(), 0);
+      expect(runs, 3);
+      s(3, true);
+      expect(s(), 0);
+      expect(runs, 4);
+    });
+  });
+}

--- a/packages/jolt/test/core/computed_test.dart
+++ b/packages/jolt/test/core/computed_test.dart
@@ -1212,11 +1212,11 @@ void main() {
       expect(computed.value, equals(5));
 
       // Force update (force=true) - should notify even if value unchanged
-      computed.notify(true);
+      computed.notify();
       expect(effectCount, equals(2)); // Effect triggered
 
       // Force update again
-      computed.notify(true);
+      computed.notify();
       expect(effectCount, equals(3)); // Effect triggered again
     });
 
@@ -1300,7 +1300,7 @@ void main() {
       expect(computeCount, equals(3)); // Recomputed but value unchanged
 
       // Force update - should notify even if equals returns true
-      computed.notify(true);
+      computed.notify();
       expect(effectCount, equals(2)); // Effect triggered
       expect(computeCount, equals(4)); // Recomputed
     });

--- a/packages/jolt/test/core/debug_test.dart
+++ b/packages/jolt/test/core/debug_test.dart
@@ -49,7 +49,7 @@ void main() {
       expect(counter.setCount, equals(1));
       expect(counter.count, equals(4));
 
-      c.notify(true);
+      c.notify();
       expect(counter.notifyCount, equals(1));
       expect(counter.count, equals(5));
 

--- a/packages/jolt/test/core/notify_test.dart
+++ b/packages/jolt/test/core/notify_test.dart
@@ -82,7 +82,7 @@ void main() {
       );
       expect(e1, equals(1));
       expect(e2, equals(1));
-      c1.notify(true);
+      c1.notify();
       expect(e1, equals(2));
       expect(e2, equals(2));
     });
@@ -135,10 +135,10 @@ void main() {
       s1.notify();
       expect(e1, equals(2));
       expect(e2, equals(2));
-      c1.notify(true);
+      c1.notify();
       expect(e1, equals(2));
       expect(e2, equals(3));
-      c2.notify(true);
+      c2.notify();
       expect(e1, equals(3));
       expect(e2, equals(4));
     });
@@ -182,7 +182,7 @@ void main() {
       s1.notify();
       expect(outerCount, equals(2));
       expect(innerCount, equals(2));
-      c1.notify(true);
+      c1.notify();
       expect(outerCount, equals(2));
       expect(innerCount, equals(3));
     });

--- a/packages/jolt/test/utils/writable_test.dart
+++ b/packages/jolt/test/utils/writable_test.dart
@@ -240,7 +240,7 @@ void main() {
 
       expect(values, equals([10]));
 
-      readonly.notify(true);
+      readonly.notify();
       expect(
           values, equals([10, 10])); // Notified even though value didn't change
     });


### PR DESCRIPTION
## Summary

- Improve reactive graph propagation for nested writes, effect scopes, and graph mutation during dirty checks.
- Separate disposed state from reactive flags so disposed nodes are fully cleaned up without reusing `ReactiveFlags`.
- Make `effectScope` participate correctly in propagation and dependency linking.
- Change `notify()` default behavior to forced propagation, keeping `notify(false)` as the explicit soft-update path.
- Add regression coverage for alien-signals issues #99, #105, and #109.
- Update computed docs in English and Chinese for the new `notify()` default.